### PR TITLE
Remove deprecated bottle :unneeded

### DIFF
--- a/Formula/deptomod.rb
+++ b/Formula/deptomod.rb
@@ -3,7 +3,6 @@ class Deptomod < Formula
   desc "Enhanced migration from dep to go modules"
   homepage "https://github.com/ldez/deptomod"
   version "0.1.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/ldez/deptomod/releases/download/v0.1.0/deptomod_v0.1.0_darwin_amd64.tar.gz"

--- a/Formula/gti.rb
+++ b/Formula/gti.rb
@@ -3,7 +3,6 @@ class Gti < Formula
   desc "Just a silly git launcher, basically. Inspired by sl"
   homepage "https://github.com/ldez/gti"
   version "1.5.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/ldez/gti/releases/download/v1.5.0/gti_v1.5.0_darwin_amd64.tar.gz"

--- a/Formula/motoko.rb
+++ b/Formula/motoko.rb
@@ -6,7 +6,6 @@ class Motoko < Formula
   desc "Based on Go modules, update a dependency to a major version"
   homepage "https://github.com/ldez/motoko"
   version "0.2.6"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
Remove deprecated `bottle :unneeded` from:
* `Formula/deptomod.rb`
* `Formula/gti.rb`
* `Formula/motoko.rb`

fixes #1